### PR TITLE
feat: Build Edit Profile Page (Personal & Household Forms)

### DIFF
--- a/frontend/src/app/routes/app/edit-profile.tsx
+++ b/frontend/src/app/routes/app/edit-profile.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { Check } from 'lucide-react';
+import { LuCheckCheck } from 'react-icons/lu';
 
-const ProfileRoute = () => {
+export default function ProfileRoute() {
   const [activeTab, setActiveTab] = useState<'personal' | 'household'>(
     'personal',
   );
@@ -71,7 +71,7 @@ const ProfileRoute = () => {
                 <label className="group flex cursor-pointer items-center gap-2 select-none">
                   <input type="checkbox" className="peer sr-only" />
                   <div className="flex h-6 w-6 items-center justify-center rounded-md border-2 border-gray-300 bg-white transition-all group-hover:border-gray-400 peer-checked:border-[#10B981] peer-checked:bg-[#10B981] peer-checked:[&_svg]:opacity-100">
-                    <Check
+                    <LuCheckCheck
                       size={16}
                       className="text-white opacity-0 transition-opacity"
                       strokeWidth={3}
@@ -85,7 +85,7 @@ const ProfileRoute = () => {
                 <label className="group flex cursor-pointer items-center gap-2 select-none">
                   <input type="checkbox" className="peer sr-only" />
                   <div className="flex h-6 w-6 items-center justify-center rounded-md border-2 border-gray-300 bg-white transition-all group-hover:border-gray-400 peer-checked:border-[#10B981] peer-checked:bg-[#10B981] peer-checked:[&_svg]:opacity-100">
-                    <Check
+                    <LuCheckCheck
                       size={16}
                       className="text-white opacity-0 transition-opacity"
                       strokeWidth={3}
@@ -192,6 +192,4 @@ const ProfileRoute = () => {
       </div>
     </div>
   );
-};
-
-export default ProfileRoute;
+}


### PR DESCRIPTION
## Description

Implemented the UI for the **Edit Profile Page** (`feat/edit-profile`)

* Interface: Switching between "Personal" and "Household" settings
* Personal Tab: Fields for Email, Phone Number, and Reminder preferences (Via Email/SMS)
* Household Tab: Fields for Household Name, Member counts, and Pet counts
* Implemented  checkboxes with specific hover and checked states (Green/White/Gray)
* Primary (Save) and Secondary (Cancel) buttons with specific color interactions
* Added a Skeleton Loader (daisyUI style) for the avatar

## Related Issue

* **Closes**: #57 

## Type of Change

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (a fix or feature that would cause existing functionality to not work as expected)
* [ ] Chore (a change to the build process or auxiliary tools and libraries)
* [ ] Documentation update

